### PR TITLE
Fixed Crashing Issue & Removed Redundant Import

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,6 @@ import getHtmls from './src/getHtmls'
 import sort from './src/sort'
 import {argv} from 'yargs'
 import dotenv from 'dotenv'
-import { isMainThread } from 'worker_threads';
 const result = dotenv.config()
 
 const packageAuthor = argv.author || `ramda`


### PR DESCRIPTION
The app was crashing showing this error:  

```
PS C:\Users\Si563011\Music\repositories\github-by-stars> npx nodemon index.js
[nodemon] 1.19.1
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: *.*
[nodemon] starting `node index.js`
C:\Users\Si563011\Music\repositories\github-by-stars\main.js:1
Error: Cannot find module 'worker_threads'
Require stack:
- C:\Users\Si563011\Music\repositories\github-by-stars\main.js
- C:\Users\Si563011\Music\repositories\github-by-stars\index.js
    at Object.<anonymous> (C:\Users\Si563011\Music\repositories\github-by-stars\main.js:1)
[nodemon] app crashed - waiting for file changes before starting...
```

Looking in `main.js` I saw that this import was not used.  
After removing it, the app started working.

